### PR TITLE
Sort release tags *after* limiting

### DIFF
--- a/cmd/hvm/use.go
+++ b/cmd/hvm/use.go
@@ -210,8 +210,13 @@ func (r *repository) fetchTags() error {
 		n = 9999
 	}
 	if n <= len(tagNames) {
-		tagNames = tagNames[len(tagNames)-n:]
+		if Config.SortAscending {
+			tagNames = tagNames[len(tagNames)-n:]
+		} else {
+			tagNames = tagNames[0 : n-1]
+		}
 	}
+
 	r.tags = tagNames
 
 	return nil

--- a/cmd/hvm/use.go
+++ b/cmd/hvm/use.go
@@ -213,7 +213,7 @@ func (r *repository) fetchTags() error {
 		if Config.SortAscending {
 			tagNames = tagNames[len(tagNames)-n:]
 		} else {
-			tagNames = tagNames[0 : n-1]
+			tagNames = tagNames[:n]
 		}
 	}
 


### PR DESCRIPTION
Thanks a lot for implementing https://github.com/jmooring/hvm/pull/13. Unfortunately, `sortAscending = false` is not very useful unless one also sets `numtagstodisplay = -1`, because the n releases *since inception* instead of *since last release - 30* are displayed.

Currently, with defaults plus `sortAscending = false`:

```
> hvm use

  1) v0.63.2               2) v0.63.1               3) v0.63.0             
  4) v0.62.2               5) v0.62.1               6) v0.62.0             
  7) v0.61.0               8) v0.60.1               9) v0.60.0             
 10) v0.59.1              11) v0.59.0              12) v0.58.3             
 13) v0.58.2              14) v0.58.1              15) v0.58.0             
 16) v0.57.2              17) v0.57.1              18) v0.57.0             
 19) v0.56.3              20) v0.56.2              21) v0.56.1             
 22) v0.56.0              23) v0.55.6              24) v0.55.5             
 25) v0.55.4              26) v0.55.3              27) v0.55.2             
 28) v0.55.1              29) v0.55.0              30) v0.54.0
```

This PR should fix that.

Note that I have almost zero experience in Golang, so please bear with me if style or anything is not how you like it.