### PR TITLE
cmd/use cmd/install: add --latest to directly install latest release tag

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -41,7 +41,7 @@ you will be prompted to add it when installation is complete.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		useLatest, err := cmd.Flags().GetBool("latest")
 		cobra.CheckErr(err)
-		
+
 		err = install(useLatest)
 		cobra.CheckErr(err)
 	},

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -39,28 +39,39 @@ To use this version when version management is disabled in the current
 directory, the cache "default" directory must be in your PATH. If it is not,
 you will be prompted to add it when installation is complete.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		err := install()
+		useLatest, err := cmd.Flags().GetBool("latest")
+		cobra.CheckErr(err)
+		
+		err = install(useLatest)
 		cobra.CheckErr(err)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(installCmd)
+	installCmd.Flags().Bool("latest", false, "Install the latest release")
 }
 
 // install sets the version of the Hugo executable to use when version
 // management is disabled in the current directory.
-func install() error {
+func install(useLatest bool) error {
 	asset := newAsset()
 	repo := newRepository()
 
-	msg := "Select a version to use when version management is disabled"
-	err := repo.selectTag(asset, msg)
-	if err != nil {
-		return err
-	}
-	if asset.tag == "" {
-		return nil // the user did not select a tag; do nothing
+	if useLatest {
+		err := repo.getLatestTag(asset)
+		if err != nil {
+			return err
+		}
+	} else {
+		msg := "Select a version to use when version management is disabled"
+		err := repo.selectTag(asset, msg)
+		if err != nil {
+			return err
+		}
+		if asset.tag == "" {
+			return nil // the user did not select a tag; do nothing
+		}
 	}
 
 	exists, err := helpers.Exists(filepath.Join(App.CacheDirPath, asset.tag))
@@ -74,7 +85,6 @@ func install() error {
 			return err
 		}
 	}
-
 	err = helpers.CopyFile(asset.getExecPath(), filepath.Join(App.CacheDirPath, App.DefaultDirName, asset.execName))
 	if err != nil {
 		return err

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -49,7 +49,7 @@ you will be prompted to add it when installation is complete.`,
 
 func init() {
 	rootCmd.AddCommand(installCmd)
-	installCmd.Flags().Bool("latest", false, "Install the latest release")
+	installCmd.Flags().Bool("latest", false, "Install the latest version")
 }
 
 // install sets the version of the Hugo executable to use when version

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -118,7 +118,7 @@ func status(cmd *cobra.Command) error {
 				fmt.Printf("Would you like to get it now? (Y/n): ")
 				fmt.Scanln(&r)
 				if len(r) == 0 || strings.ToLower(string(r[0])) == "y" {
-					err = use(true,false)
+					err = use(true, false)
 					if err != nil {
 						return err
 					}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -118,7 +118,7 @@ func status(cmd *cobra.Command) error {
 				fmt.Printf("Would you like to get it now? (Y/n): ")
 				fmt.Scanln(&r)
 				if len(r) == 0 || strings.ToLower(string(r[0])) == "y" {
-					err = use(true)
+					err = use(true,false)
 					if err != nil {
 						return err
 					}

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -62,7 +62,7 @@ tag to an .hvm file.`,
 func init() {
 	rootCmd.AddCommand(useCmd)
 	useCmd.Flags().Bool("useVersionInDotFile", false, "Use the version specified by the "+App.DotFileName+" file\nin the current directory")
-	useCmd.Flags().Bool("latest", false, "Use the latest release")
+	useCmd.Flags().Bool("latest", false, "Use the latest version")
 }
 
 // A repository is a GitHub repository.

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -69,7 +69,7 @@ func init() {
 type repository struct {
 	owner     string         // account owner of the GitHub repository
 	name      string         // name of the GitHub repository without the .git extension
-	tags      []string       // repository tags in semver ascending order
+	tags      []string       // repository tags
 	latestTag string         // latest repository tag
 	client    *github.Client // a GitHub API client
 }

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -50,12 +50,10 @@ tag to an .hvm file.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		useVersionInDotFile, err := cmd.Flags().GetBool("useVersionInDotFile")
 		cobra.CheckErr(err)
+		err = use(useVersionInDotFile)
+
 		useLatest, err := cmd.Flags().GetBool("latest")
 		cobra.CheckErr(err)
-
-		err = use(useVersionInDotFile, useLatest)
-		cobra.CheckErr(err)
-
 	},
 }
 

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -253,7 +253,7 @@ func (r *repository) fetchTags() error {
 	return nil
 }
 
-// latestTag returns the most recent tag from repository.
+// getLatestTag returns the most recent tag from repository.
 func (r *repository) getLatestTag(a *asset) error {
 	if 1 > len(r.tags) {
 		return fmt.Errorf("no latest release found")

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -70,7 +70,7 @@ type repository struct {
 	owner     string         // account owner of the GitHub repository
 	name      string         // name of the GitHub repository without the .git extension
 	tags      []string       // repository tags in semver ascending order
-	latestTag string         // only retrieve the latest tag
+	latestTag string         // latest repository tag
 	client    *github.Client // a GitHub API client
 }
 


### PR DESCRIPTION
implements: #85

-  switch name:  `--latest` switch
- kept `useLatest as name for the flag variable
  - just `if latest` reads bad for me because it does not check _if_ its latest but tells to _use the latest_ version
 