### PR TITLE
stop assigning the entire hugo function to hugo_bin

### DIFF
--- a/cmd/aliases/zsh.sh
+++ b/cmd/aliases/zsh.sh
@@ -12,7 +12,7 @@ hugo() {
         return 1
       fi
     else
-      if ! hugo_bin=$(which hugo); then
+      if ! hugo_bin=$(whence -p hugo); then
         >&2 printf "Command not found.\\n"
         return 1
       fi


### PR DESCRIPTION
If there is no `hugo` on the $PATH, ZSH will assign the entire contents of the function `hugo()` to the variable `hugo_bin`, and then try to run it, producing a very confusing "command not found" error.

As explained in [this StackOverflow answer][1], in ZSH the `which` command is equivalent to `whence -c`, which prints the entire contents of any functions with the given name. What we actually want in this situation is `whence -p`, which will print the full path to any commands with the given name.

[1]: https://stackoverflow.com/a/14196212