### PR TITLE
all: Reorganize codebase with separated concerns

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,9 +22,9 @@ builds:
         goarch: arm64
     ldflags:
       - -s -w
-      - -X github.com/jmooring/hvm/cmd.version={{.Version}}
-      - -X github.com/jmooring/hvm/cmd.commitHash={{.ShortCommit}}
-      - -X github.com/jmooring/hvm/cmd.buildDate={{.Date}}
+      - -X github.com/jmooring/hvm/pkg/version.Version={{.Version}}
+      - -X github.com/jmooring/hvm/pkg/version.CommitHash={{.ShortCommit}}
+      - -X github.com/jmooring/hvm/pkg/version.BuildDate={{.Date}}
 archives:
   - formats: ['tar.gz']
     name_template: >-

--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// aliasCmd represents the alias command
+// aliasCmd represents the alias command.
 var aliasCmd = &cobra.Command{
 	Use:   "alias",
 	Short: "Generate an alias function for the specified shell",
@@ -30,6 +30,7 @@ See each sub-command's help for details on how to use the generated code.`,
 	},
 }
 
+// init registers the alias command with the gen command.
 func init() {
 	genCmd.AddCommand(aliasCmd)
 }

--- a/cmd/bash.go
+++ b/cmd/bash.go
@@ -25,7 +25,7 @@ import (
 //go:embed aliases/bash.sh
 var bashScript string
 
-// bashCmd represents the bash command
+// bashCmd represents the bash command.
 var bashCmd = &cobra.Command{
 	Use:   "bash",
 	Short: "Generate an alias function for bash",
@@ -42,6 +42,7 @@ message, set the "hvm_show_status" variable to "false" in the alias function.`,
 	},
 }
 
+// init registers the bash command with the alias command.
 func init() {
 	aliasCmd.AddCommand(bashCmd)
 }

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -22,10 +22,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/jmooring/hvm/pkg/cache"
 	"github.com/spf13/cobra"
 )
 
-// cleanCmd represents the clean command
+// cleanCmd represents the clean command.
 var cleanCmd = &cobra.Command{
 	Use:   "clean",
 	Short: "Clean the cache",
@@ -37,6 +38,7 @@ command.`,
 	},
 }
 
+// init registers the clean command with the root command.
 func init() {
 	rootCmd.AddCommand(cleanCmd)
 }
@@ -44,7 +46,7 @@ func init() {
 // clean cleans the cache, excluding the version installed with the "install"
 // command.
 func clean() error {
-	cacheSize, err := getCacheSize()
+	cacheSize, err := cache.Size(app.CacheDirPath, app.DefaultDirName)
 	if err != nil {
 		return err
 	}
@@ -66,14 +68,14 @@ func clean() error {
 		}
 
 		if strings.EqualFold(string(r[0]), "y") {
-			d, err := os.ReadDir(App.CacheDirPath)
+			d, err := os.ReadDir(app.CacheDirPath)
 			if err != nil {
 				return err
 			}
 
 			for _, f := range d {
-				if f.Name() != App.DefaultDirName {
-					err := os.RemoveAll(filepath.Join(App.CacheDirPath, f.Name()))
+				if f.Name() != app.DefaultDirName {
+					err := os.RemoveAll(filepath.Join(app.CacheDirPath, f.Name()))
 					if err != nil {
 						return err
 					}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rogpeppe/go-internal/testscript"
 )
 
+// TestCommand runs testscripts for the main command set.
 func TestCommand(t *testing.T) {
 	testscript.Run(t, testscript.Params{
 		Dir:   "testscripts",
@@ -32,6 +33,7 @@ func TestCommand(t *testing.T) {
 	})
 }
 
+// TestCommandConfig runs testscripts for the config command.
 func TestCommandConfig(t *testing.T) {
 	testscript.Run(t, testscript.Params{
 		Dir:   "testscripts/config",
@@ -39,6 +41,7 @@ func TestCommandConfig(t *testing.T) {
 	})
 }
 
+// TestCommandInstall runs testscripts for the install command.
 func TestCommandInstall(t *testing.T) {
 	testscript.Run(t, testscript.Params{
 		Dir:   "testscripts/install",
@@ -46,6 +49,7 @@ func TestCommandInstall(t *testing.T) {
 	})
 }
 
+// TestCommandRemove runs testscripts for the remove command.
 func TestCommandRemove(t *testing.T) {
 	testscript.Run(t, testscript.Params{
 		Dir:   "testscripts/remove",
@@ -53,6 +57,7 @@ func TestCommandRemove(t *testing.T) {
 	})
 }
 
+// TestCommandStatus runs testscripts for the status command.
 func TestCommandStatus(t *testing.T) {
 	testscript.Run(t, testscript.Params{
 		Dir:   "testscripts/status",
@@ -60,6 +65,7 @@ func TestCommandStatus(t *testing.T) {
 	})
 }
 
+// TestCommandUse runs testscripts for the use command.
 func TestCommandUse(t *testing.T) {
 	testscript.Run(t, testscript.Params{
 		Dir:   "testscripts/use",
@@ -67,6 +73,7 @@ func TestCommandUse(t *testing.T) {
 	})
 }
 
+// setup initializes the test environment with necessary environment variables.
 func setup(env *testscript.Env) error {
 	env.Setenv("HVM_GITHUBTOKEN", os.Getenv("HVM_GITHUBTOKEN"))
 	switch runtime.GOOS {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// configCmd represents the config command
+// configCmd represents the config command.
 var configCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Display the current configuration",
@@ -34,6 +34,7 @@ var configCmd = &cobra.Command{
 	},
 }
 
+// init registers the config command with the root command.
 func init() {
 	rootCmd.AddCommand(configCmd)
 }
@@ -41,11 +42,11 @@ func init() {
 // displayConfig displays the current configuration and the path to the
 // configuration file.
 func displayConfig() error {
-	t, err := toml.Marshal(Config)
+	t, err := toml.Marshal(config)
 	cobra.CheckErr(err)
 
 	fmt.Println(string(t))
-	fmt.Println("Configuration file:", App.ConfigFilePath)
+	fmt.Println("Configuration file:", app.ConfigFilePath)
 
 	return nil
 }

--- a/cmd/disable.go
+++ b/cmd/disable.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// disableCmd represents the disable command
+// disableCmd represents the disable command.
 var disableCmd = &cobra.Command{
 	Use:   "disable",
 	Short: "Disable version management in the current directory",
@@ -35,19 +35,20 @@ var disableCmd = &cobra.Command{
 	},
 }
 
+// init registers the disable command with the root command.
 func init() {
 	rootCmd.AddCommand(disableCmd)
 }
 
 // disable disables version management in the current directory.
 func disable() error {
-	exists, err := helpers.Exists(App.DotFilePath)
+	exists, err := helpers.Exists(app.DotFilePath)
 	if err != nil {
 		return err
 	}
 
 	if exists {
-		err := os.Remove(App.DotFilePath)
+		err := os.Remove(app.DotFilePath)
 		if err != nil {
 			return err
 		}

--- a/cmd/fish.go
+++ b/cmd/fish.go
@@ -25,7 +25,7 @@ import (
 //go:embed aliases/fish.sh
 var fishScript string
 
-// fishCmd represents the fish command
+// fishCmd represents the fish command.
 var fishCmd = &cobra.Command{
 	Use:   "fish",
 	Short: "Generate an alias function for fish",
@@ -42,6 +42,7 @@ message, set the "hvm_show_status" variable to "false" in the alias function.`,
 	},
 }
 
+// init registers the fish command with the alias command.
 func init() {
 	aliasCmd.AddCommand(fishCmd)
 }

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// genCmd represents the gen command
+// genCmd represents the gen command.
 var genCmd = &cobra.Command{
 	Use:   "gen",
 	Short: "Generate various files",
@@ -29,6 +29,7 @@ var genCmd = &cobra.Command{
 	},
 }
 
+// init registers the gen command with the root command.
 func init() {
 	rootCmd.AddCommand(genCmd)
 }

--- a/cmd/powershell.go
+++ b/cmd/powershell.go
@@ -25,7 +25,7 @@ import (
 //go:embed aliases/powershell.ps1
 var powershellScript string
 
-// powershellCmd represents the powershell command
+// powershellCmd represents the powershell command.
 var powershellCmd = &cobra.Command{
 	Use:   "powershell",
 	Short: "Generate an alias function for powershell",
@@ -48,6 +48,7 @@ message, set the "hvm_show_status" variable to "$false" in the alias function.
 	},
 }
 
+// init registers the powershell command with the alias command.
 func init() {
 	aliasCmd.AddCommand(powershellCmd)
 }

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// removeCmd represents the remove command
+// removeCmd represents the remove command.
 var removeCmd = &cobra.Command{
 	Use:     "remove",
 	Aliases: []string{"uninstall"},
@@ -36,17 +36,19 @@ var removeCmd = &cobra.Command{
 	},
 }
 
+// init registers the remove command with the root command.
 func init() {
 	rootCmd.AddCommand(removeCmd)
 }
 
+// remove removes the default Hugo version installed by the install command.
 func remove() error {
-	exists, err := helpers.Exists(App.DefaultDirPath)
+	exists, err := helpers.Exists(app.DefaultDirPath)
 	if err != nil {
 		return err
 	}
 	if exists {
-		err = os.RemoveAll(App.DefaultDirPath)
+		err = os.RemoveAll(app.DefaultDirPath)
 		if err != nil {
 			return err
 		}

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// resetCmd represents the reset command
+// resetCmd represents the reset command.
 var resetCmd = &cobra.Command{
 	Use:    "reset",
 	Hidden: true,
@@ -37,6 +37,7 @@ configuration and cache directories.`,
 	},
 }
 
+// init registers the reset command with the root command.
 func init() {
 	rootCmd.AddCommand(resetCmd)
 }
@@ -60,11 +61,11 @@ func reset() error {
 			if err != nil {
 				return err
 			}
-			err = os.RemoveAll(App.ConfigDirPath)
+			err = os.RemoveAll(app.ConfigDirPath)
 			if err != nil {
 				return err
 			}
-			err = os.RemoveAll(App.CacheDirPath)
+			err = os.RemoveAll(app.CacheDirPath)
 			if err != nil {
 				return err
 			}

--- a/cmd/use_test.go
+++ b/cmd/use_test.go
@@ -19,14 +19,16 @@ package cmd
 import (
 	"fmt"
 	"testing"
+
+	"github.com/jmooring/hvm/pkg/cache"
+	"github.com/jmooring/hvm/pkg/repository"
 )
 
-func newMockRepo() *repository {
-	r := repository{
-		tags:      []string{"v1.2.3", "v1.2.2", "v1.2.1"},
-		latestTag: "v1.2.3",
-	}
-	return &r
+// newMockRepo creates a mock repository for testing with predefined tags.
+func newMockRepo() *repository.Repository {
+	r := &repository.Repository{}
+	r.SetTagsForTesting([]string{"v1.2.3", "v1.2.2", "v1.2.1"}, "v1.2.3")
+	return r
 }
 
 var testCases = []struct {
@@ -55,17 +57,18 @@ var testCases = []struct {
 	{"1.2.3.4", ""},
 }
 
+// TestGetTagFromString tests the GetTagFromString repository method.
 func TestGetTagFromString(t *testing.T) {
 	// mock needed elements and sort config
-	Config.SortAscending = false
+	config.SortAscending = false
 	repo := newMockRepo()
-	asset := newAsset()
+	asset := repository.NewAsset(cache.ExecName())
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("[%s] ShouldBe [%s]", tc.given, tc.want), func(t *testing.T) {
-			asset.tag = ""
-			err := repo.getTagFromString(asset, tc.given)
-			if asset.tag != tc.want {
-				t.Fatalf("given(%s) -> calculated(%s) -> want(%s) : %s", tc.given, asset.tag, tc.want, err)
+			asset.Tag = ""
+			err := repo.GetTagFromString(asset, tc.given)
+			if asset.Tag != tc.want {
+				t.Fatalf("given(%s) -> calculated(%s) -> want(%s) : %s", tc.given, asset.Tag, tc.want, err)
 			}
 		})
 	}

--- a/cmd/zsh.go
+++ b/cmd/zsh.go
@@ -25,7 +25,7 @@ import (
 //go:embed aliases/zsh.sh
 var zshScript string
 
-// zshCmd represents the zsh command
+// zshCmd represents the zsh command.
 var zshCmd = &cobra.Command{
 	Use:   "zsh",
 	Short: "Generate an alias function for zsh",
@@ -42,6 +42,7 @@ message, set the "hvm_show_status" variable to "false" in the alias function.`,
 	},
 }
 
+// init registers the zsh command with the alias command.
 func init() {
 	aliasCmd.AddCommand(zshCmd)
 }

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	cmd "github.com/jmooring/hvm/cmd"
 )
 
+// main is the entry point for the hvm application.
 func main() {
 	cmd.Execute()
 }

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/jmooring/hvm/pkg/helpers"
 )
 
+// TestExtract tests the Extract function for various archive formats.
 func TestExtract(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,58 @@
+/*
+Copyright © 2026 Joe Mooring <joe.mooring@veriphor.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cache provides cache-related operations.
+package cache
+
+import (
+	"io/fs"
+	"os"
+	"runtime"
+	"strings"
+)
+
+// ExecName returns the name of the executable file based on the OS.
+func ExecName() string {
+	if runtime.GOOS == "windows" {
+		return "hugo.exe"
+	}
+	return "hugo"
+}
+
+// Size returns the size of the cache directory, in bytes, excluding
+// the specified exclude directory.
+func Size(cachePath, excludeDir string) (int64, error) {
+	var size int64 = 0
+	err := fs.WalkDir(os.DirFS(cachePath), ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() && !strings.HasPrefix(path, excludeDir) {
+			fi, err := d.Info()
+			if err != nil {
+				return err
+			}
+			size += fi.Size()
+		}
+
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return size, nil
+}

--- a/pkg/dotfile/dotfile.go
+++ b/pkg/dotfile/dotfile.go
@@ -1,0 +1,101 @@
+/*
+Copyright © 2026 Joe Mooring <joe.mooring@veriphor.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package dotfile provides operations on the application dot file.
+package dotfile
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+// Manager handles operations on the dot file.
+type Manager struct {
+	filePath string
+	fileName string
+	appName  string
+}
+
+// NewManager creates a new dotfile manager.
+func NewManager(filePath, fileName, appName string) *Manager {
+	return &Manager{
+		filePath: filePath,
+		fileName: fileName,
+		appName:  appName,
+	}
+}
+
+// Read reads the version from the dot file in the current directory, or
+// returns an empty string if the file does not exist.
+func (m *Manager) Read() (string, error) {
+	exists, err := fileExists(m.filePath)
+	if err != nil {
+		return "", err
+	}
+	if !exists {
+		return "", nil
+	}
+
+	f, err := os.Open(m.filePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(f)
+	if err != nil {
+		return "", err
+	}
+
+	theFix := fmt.Sprintf("run \"%s use\" to select a version, or \"%s disable\" to remove the file", m.appName, m.appName)
+
+	dotFileContent := strings.TrimSpace(buf.String())
+	if dotFileContent == "" {
+		return "", fmt.Errorf("the %s file in the current directory is empty: %s", m.fileName, theFix)
+	}
+
+	if !semver.IsValid(dotFileContent) {
+		return "", fmt.Errorf("the %s file in the current directory has an invalid format: %s", m.fileName, theFix)
+	}
+
+	return dotFileContent, nil
+}
+
+// Write writes the version to the dot file in the current directory.
+func (m *Manager) Write(version string) error {
+	err := os.WriteFile(m.filePath, []byte(version), 0o644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// fileExists checks if a file exists.
+func fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -1,0 +1,56 @@
+/*
+Copyright © 2026 Joe Mooring <joe.mooring@veriphor.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package github provides functionality for interacting with the GitHub API.
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+)
+
+// NewClient creates and returns a new GitHub API client. If token is empty,
+// returns an unauthenticated client.
+func NewClient(token string) *github.Client {
+	if token == "" {
+		return github.NewClient(nil)
+	}
+
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+
+	return github.NewClient(tc)
+}
+
+// GetLatestRelease fetches the latest release for a given repository.
+func GetLatestRelease(ctx context.Context, client *github.Client, owner, repo string) (string, error) {
+	release, _, err := client.Repositories.GetLatestRelease(ctx, owner, repo)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch latest release: %w", err)
+	}
+
+	if release.TagName == nil {
+		return "", fmt.Errorf("release found, but tag name is nil")
+	}
+
+	return *release.TagName, nil
+}

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 )
 
+// TestIsDir tests the IsDir function.
 func TestIsDir(t *testing.T) {
 	t.Parallel()
 
@@ -68,6 +69,7 @@ func TestIsDir(t *testing.T) {
 	}
 }
 
+// TestExists tests the Exists function.
 func TestExists(t *testing.T) {
 	t.Parallel()
 
@@ -111,6 +113,7 @@ func TestExists(t *testing.T) {
 	}
 }
 
+// TestIsEmpty tests the IsEmpty function.
 func TestIsEmpty(t *testing.T) {
 	t.Parallel()
 
@@ -164,6 +167,7 @@ func TestIsEmpty(t *testing.T) {
 	}
 }
 
+// TestCopyFile tests the CopyFile function.
 func TestCopyFile(t *testing.T) {
 	t.Parallel()
 
@@ -215,6 +219,7 @@ func TestCopyFile(t *testing.T) {
 	}
 }
 
+// TestCopyDirectoryContent tests the CopyDirectoryContent function.
 func TestCopyDirectoryContent(t *testing.T) {
 	t.Parallel()
 
@@ -273,6 +278,7 @@ func TestCopyDirectoryContent(t *testing.T) {
 	}
 }
 
+// TestRemoveDirectoryContent tests the RemoveDirectoryContent function.
 func TestRemoveDirectoryContent(t *testing.T) {
 	t.Parallel()
 
@@ -316,6 +322,7 @@ func TestRemoveDirectoryContent(t *testing.T) {
 	}
 }
 
+// TestIsString tests the IsString function.
 func TestIsString(t *testing.T) {
 	type args struct {
 		i any

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -1,0 +1,303 @@
+/*
+Copyright © 2026 Joe Mooring <joe.mooring@veriphor.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package repository provides types and operations for managing GitHub releases.
+package repository
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"runtime"
+	"slices"
+	"strings"
+
+	"github.com/google/go-github/github"
+	"golang.org/x/mod/semver"
+)
+
+// Repository represents a GitHub repository.
+type Repository struct {
+	owner     string         // Owner of the GitHub repository
+	name      string         // Name of the GitHub repository
+	tags      []string       // Repository tags
+	latestTag string         // Latest repository tag
+	client    *github.Client // A GitHub API client
+}
+
+// Asset represents a GitHub release asset for a given release, OS, and architecture.
+type Asset struct {
+	ArchiveDirPath  string // Directory path of the downloaded archive
+	ArchiveExt      string // Extension of the downloaded archive: pkg, tar.gz, or zip
+	ArchiveFilePath string // File path of the downloaded archive
+	ArchiveURL      string // Download URL for this asset
+	Tag             string // User-selected tag associated with the release for this asset
+	ExecName        string // Name of the executable file
+}
+
+// NewRepository creates a new Repository instance and fetches tags.
+func NewRepository(owner, name string, client *github.Client) (*Repository, error) {
+	r := &Repository{
+		owner:     owner,
+		name:      name,
+		client:    client,
+		latestTag: "",
+	}
+
+	err := r.FetchTags()
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// NewAsset creates a new Asset instance.
+func NewAsset(execName string) *Asset {
+	return &Asset{
+		ExecName: execName,
+	}
+}
+
+// FetchTags fetches tags associated with recent releases.
+func (r *Repository) FetchTags() error {
+	opts := &github.ListOptions{PerPage: 100}
+
+	var tags []*github.RepositoryTag
+	for {
+		tagsThisPage, resp, err := r.client.Repositories.ListTags(context.Background(), r.owner, r.name, opts)
+		if err != nil {
+			return err
+		}
+		tags = append(tags, tagsThisPage...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	if len(tags) == 0 {
+		return fmt.Errorf("this repository has no tags")
+	}
+
+	var tagNames []string
+	for _, tag := range tags {
+		// Releases prior to v0.54.0 were not semantically versioned.
+		if semver.Compare(tag.GetName(), "v0.54.0") >= 0 {
+			tagNames = append(tagNames, tag.GetName())
+		}
+	}
+
+	r.latestTag = tagNames[0]
+	r.tags = tagNames
+
+	return nil
+}
+
+// GetLatestTag returns the most recent tag from the repository.
+func (r *Repository) GetLatestTag(a *Asset) error {
+	if r.latestTag == "" {
+		return fmt.Errorf("no latest release found")
+	}
+	a.Tag = r.latestTag
+	return nil
+}
+
+// GetTagFromString parses and validates a version string and sets it on the asset.
+func (r *Repository) GetTagFromString(a *Asset, version string) error {
+	inputVersion := version
+	// fast return for simple cases
+	if version == "latest" {
+		return r.GetLatestTag(a)
+	}
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+	if semver.Compare(version, "") == 0 {
+		return fmt.Errorf("invalid tag: %s", inputVersion)
+	}
+	if !slices.Contains(r.tags, version) {
+		return fmt.Errorf("tag \"%s\" not found in repository", inputVersion)
+	}
+	a.Tag = version
+	return nil
+}
+
+// SelectTag prompts the user to select a tag from a list of recent tags.
+// sortAscending determines the sort order, numTagsToDisplay limits the count.
+// excludeExistsFn is used to check if a tag is already cached.
+func (r *Repository) SelectTag(a *Asset, msg string, sortAscending bool, numTagsToDisplay int, excludeExistsFn func(string) (bool, error)) error {
+	tags := r.tags
+
+	// Make a copy for sorting operations
+	displayTags := make([]string, len(tags))
+	copy(displayTags, tags)
+
+	// Apply sorting if requested
+	if sortAscending {
+		semver.Sort(displayTags)
+	}
+
+	// Apply limit
+	n := numTagsToDisplay
+	if n < 0 {
+		n = 9999
+	}
+
+	if n <= len(displayTags) {
+		if sortAscending {
+			displayTags = displayTags[len(displayTags)-n:]
+		} else {
+			displayTags = displayTags[:n]
+		}
+	}
+
+	// Display tags
+	fmt.Println()
+	for i, tag := range displayTags {
+		exists, err := excludeExistsFn(tag)
+		if err != nil {
+			return err
+		}
+		var flag string
+		if exists {
+			flag = "[cached]"
+		}
+		// The tags array is zero-based, but choices are one-based.
+		fmt.Printf("%-25s", fmt.Sprintf("%3d) %s %s", i+1, tag, flag))
+		if (i+1)%3 == 0 {
+			fmt.Print("\n")
+		} else if i == len(displayTags)-1 {
+			fmt.Print("\n")
+		}
+	}
+
+	// Prompt and collect user input
+	fmt.Println()
+	fmt.Printf("%s: ", msg)
+
+	for a.Tag == "" {
+		var rs string
+		fmt.Scanln(&rs)
+
+		if rs == "" {
+			fmt.Println("Canceled.")
+			return nil
+		}
+
+		// Parse selection
+		selection := 0
+		_, err := fmt.Sscanf(strings.TrimSpace(rs), "%d", &selection)
+		if err != nil || selection < 1 || selection > len(displayTags) {
+			fmt.Printf("Please enter a number between 1 and %d, or press Enter to cancel: ", len(displayTags))
+		} else {
+			a.Tag = displayTags[selection-1]
+		}
+	}
+
+	return nil
+}
+
+// FetchDownloadURL fetches the download URL for the user-selected tag.
+// cacheLookupFn is used to check if a cached version exists.
+func (r *Repository) FetchDownloadURL(a *Asset) error {
+	version := a.Tag[1:]
+	pattern := ""
+	// The archive file names were changed with the release of v0.103.0.
+	if semver.Compare(a.Tag, "v0.103.0") == -1 {
+		// prior to v0.103.0
+		switch runtime.GOOS {
+		case "darwin":
+			pattern = `hugo_extended_` + version + `_macOS-64bit.tar.gz`
+		case "windows":
+			pattern = `hugo_extended_` + version + `_Windows-64bit.zip`
+		case "linux":
+			pattern = `hugo_extended_` + version + `_Linux-64bit.tar.gz`
+			if runtime.GOARCH == "arm64" {
+				pattern = `hugo_extended_` + version + `_Linux-ARM64.deb`
+			}
+		default:
+			return fmt.Errorf("unsupported operating system")
+		}
+	} else {
+		// v0.103.0 and later
+		switch runtime.GOOS {
+		case "darwin":
+			// The macOS archive file names were changed with the release of v0.153.0.
+			if semver.Compare(a.Tag, "v0.153.0") == -1 {
+				// prior to v0.153.0
+				pattern = `hugo_extended_` + version + `_darwin-universal.tar.gz`
+			} else {
+				// v0.153.0 and later
+				pattern = `hugo_extended_` + version + `_darwin-universal.pkg`
+			}
+		case "windows":
+			pattern = `hugo_extended_` + version + `_windows-` + runtime.GOARCH + `.zip`
+		case "linux":
+			pattern = `hugo_extended_` + version + `_linux-` + runtime.GOARCH + `.tar.gz`
+		default:
+			return fmt.Errorf("unsupported operating system")
+		}
+	}
+	re := regexp.MustCompile(pattern)
+
+	release, _, err := r.client.Repositories.GetReleaseByTag(context.Background(), r.owner, r.name, a.Tag)
+	if err != nil {
+		return err
+	}
+
+	for _, asset := range release.Assets {
+		archiveURL := asset.GetBrowserDownloadURL()
+		if re.MatchString(archiveURL) {
+			a.ArchiveURL = archiveURL
+			switch {
+			case strings.HasSuffix(a.ArchiveURL, ".pkg"):
+				a.ArchiveExt = "pkg"
+			case strings.HasSuffix(a.ArchiveURL, ".tar.gz"):
+				a.ArchiveExt = "tar.gz"
+			case strings.HasSuffix(a.ArchiveURL, ".zip"):
+				a.ArchiveExt = "zip"
+			default:
+				return fmt.Errorf("unable to determine archive extension")
+			}
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unable to find download for %s %s/%s", a.Tag, runtime.GOOS, runtime.GOARCH)
+}
+
+// ExecPath returns the path of the executable file for this asset.
+func (a *Asset) ExecPath(cachePath string) string {
+	return fmt.Sprintf("%s/%s/%s", cachePath, a.Tag, a.ExecName)
+}
+
+// Tags returns the list of available tags.
+func (r *Repository) Tags() []string {
+	return r.tags
+}
+
+// LatestTag returns the latest tag.
+func (r *Repository) LatestTag() string {
+	return r.latestTag
+}
+
+// SetTagsForTesting allows tests to set tags directly.
+// This is exported for testing purposes only.
+func (r *Repository) SetTagsForTesting(tags []string, latestTag string) {
+	r.tags = tags
+	r.latestTag = latestTag
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,121 @@
+/*
+Copyright © 2026 Joe Mooring <joe.mooring@veriphor.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package version provides build and version information.
+package version
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"time"
+)
+
+// These variables are optionally set at build time via ldflags.
+// For example:
+//
+//	-X github.com/jmooring/hvm/pkg/version.Version=v1.2.3
+//	-X github.com/jmooring/hvm/pkg/version.CommitHash=abcdef7
+//	-X github.com/jmooring/hvm/pkg/version.BuildDate=2026-01-09T00:00:00Z
+var (
+	Version    string
+	CommitHash string
+	BuildDate  string
+)
+
+// Info contains build and version metadata.
+type Info struct {
+	Name       string
+	Version    string
+	CommitHash string
+	BuildDate  string
+}
+
+// NewInfo creates a new Info instance with current build information.
+func NewInfo(name string) Info {
+	v := Version
+	if v == "" {
+		v = getDynamicVersion()
+	}
+
+	ch := CommitHash
+	if ch == "" {
+		ch = getShortCommitHash()
+	}
+
+	bd := BuildDate
+	if bd == "" {
+		bd = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	return Info{
+		Name:       name,
+		Version:    v,
+		CommitHash: ch,
+		BuildDate:  bd,
+	}
+}
+
+// String returns a formatted version string with all metadata.
+func (i Info) String() string {
+	v := fmt.Sprintf("%s %s %s/%s %s %s", i.Name, i.Version, runtime.GOOS, runtime.GOARCH, i.CommitHash, i.BuildDate)
+	return strings.Join(strings.Fields(v), " ")
+}
+
+// getShortCommitHash returns the first seven characters of the VCS revision
+// (Git commit SHA) from the embedded build information. It returns an empty
+// string if the build information is unavailable or the binary was not
+// built within a version control system.
+func getShortCommitHash() string {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				hash := setting.Value
+				if len(hash) > 7 {
+					return hash[:7]
+				}
+				return hash
+			}
+		}
+	}
+	return ""
+}
+
+// getDynamicVersion returns the application version from the embedded build
+// information. For tagged releases, it returns the tag (e.g., "v0.9.0"). For
+// development builds, it truncates the Go-generated pseudo-version to its
+// base and suffixes it with "-dev" (e.g., "v0.9.1-dev"). It returns "dev"
+// if the build information is unavailable.
+func getDynamicVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok || info.Main.Version == "" || info.Main.Version == "(devel)" {
+		return "dev"
+	}
+
+	v := info.Main.Version // e.g., "v0.9.1-0.20230101-abcdef" (Pseudo-version)
+
+	// A pseudo-version always contains a dash and a timestamp-like string.
+	// Examples: v0.9.1-0.2023... or v0.9.1-dev.0.2023...
+	if strings.Contains(v, "-0.") || strings.Contains(v, "-dev.") {
+		// Split at the first dash to get just the "v0.9.1" part
+		parts := strings.Split(v, "-")
+		return parts[0] + "-dev"
+	}
+
+	// If it's a clean tag (v0.9.0), it returns as-is.
+	return v
+}


### PR DESCRIPTION
- Created pkg/github for GitHub API client functionality
- Created pkg/version for build and version information management
- Created pkg/dotfile for dot file read/write operations
- Created pkg/cache for cache-related operations (size calculation, exec names)
- Created pkg/repository for GitHub release management (Asset and Repository types)
- Moved version/build metadata functions from cmd.go to pkg/version
- Updated all cmd files to use new packages instead of local functions
- Removed duplicate/private functions from cmd files