### PR TITLE
cmd: Add support for HVM_GITHUB_TOKEN with high precedence

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -141,6 +141,9 @@ func initConfig() {
 
 	// Get config values from env vars.
 	viper.SetEnvPrefix(strings.ToUpper(app.Name))
+	if val := os.Getenv("HVM_GITHUB_TOKEN"); val != "" {
+		viper.Set("githubToken", val)
+	}
 	viper.AutomaticEnv()
 
 	// Validate config values.

--- a/cmd/testscripts/config/config_with_env_vars.txtar
+++ b/cmd/testscripts/config/config_with_env_vars.txtar
@@ -1,16 +1,30 @@
-# User cache and config dirs (we use os.UserCacheDir and os.UserCongfigDir)
+# User cache and config dirs (we use os.UserCacheDir and os.UserConfigDir)
 [darwin] mkdir "$HOME/Library/Caches"
 [darwin] mkdir "$HOME/Library/Application Support"
 
+# Test legacy variable
 env HVM_GITHUBTOKEN=my-token
 env HVM_NUMTAGSTODISPLAY=67
 env HVM_SORTASCENDING=false
-
-# Test
 exec hvm config
 stdout 'githubToken = ''my-token''\n'
 stdout 'numTagsToDisplay = 67\n'
 stdout 'sortAscending = false\n'
+
+# Test new variable
+# We overwrite the environment for this step to check the underscored version
+env HVM_GITHUBTOKEN=''
+env HVM_GITHUB_TOKEN=my-new-token
+exec hvm config
+stdout 'githubToken = ''my-new-token''\n'
+
+# Test Precedence (Underscored wins over legacy)
+env HVM_GITHUBTOKEN=legacy-token
+env HVM_GITHUB_TOKEN=priority-token
+exec hvm config
+stdout 'githubToken = ''priority-token'''
+
+# Verify Paths
 [darwin] stdout 'Configuration file: .+/home/Library/Application Support/hvm/config\.toml\n'
 [linux] stdout 'Configuration file: .+/config/hvm/config\.toml\n'
 [windows] stdout 'Configuration file: .+\\config\\hvm\\config\.toml\n'


### PR DESCRIPTION
Check for HVM_GITHUB_TOKEN in the environment and set it in the configuration. This allows the app to read both HVM_GITHUB_TOKEN and HVM_GITHUBTOKEN, with the underscored version taking priority over the non-underscored version and the configuration file.