### PR TITLE
cmd/aliases: Use Write-Host for powershell alias output (avoid redirect)

### DIFF
--- a/cmd/aliases/powershell.ps1
+++ b/cmd/aliases/powershell.ps1
@@ -4,8 +4,8 @@ function Hugo-Override {
   Set-Variable -Name "hugo_bin" -Value $(hvm status --printExecPathCached)
   If ($hugo_bin) {
     If ($hvm_show_status) {
-      echo "Hugo version management is enabled in this directory."
-      echo "Run 'hvm status' for details, or 'hvm disable' to disable.`n"
+      Write-Host "Hugo version management is enabled in this directory."
+      Write-Host "Run 'hvm status' for details, or 'hvm disable' to disable.`n"
     }
     & "$hugo_bin" $args
   } Else {
@@ -20,7 +20,7 @@ function Hugo-Override {
       If ($hugo_bin) {
         & "$hugo_bin" $args
       } Else {
-        echo "Command not found"
+        Write-Error "Command not found"
       }
     }
   }


### PR DESCRIPTION
This fix will replace usage of `Write-Output` with `Write-Host`.

Normal usage in a Shell will have unchanged experience.
Redirecting STDOUT will NOT send the _powershell alias_ generated messages to the output stream
If one needs all output redirect all `*>` will do

Fixes: #222 

Tested on: Microsoft Windows 10.0.26200
- Powershell Core 7.5.5 & 7.6.0
- Windows Powershell 5.1.26100.8115