### PR TITLE
cmd/aliases: limit Get-Command to return first found executable

### DIFF
--- a/cmd/aliases/powershell.ps1
+++ b/cmd/aliases/powershell.ps1
@@ -14,7 +14,7 @@ function Hugo-Override {
             hvm use --useVersionInDotFile
             if ($LASTEXITCODE -ne 0) { return }
         } else {
-            $HugoCommand = Get-Command -Name hugo.exe -ErrorAction SilentlyContinue -CommandType Application
+            $HugoCommand = Get-Command -Name hugo.exe -ErrorAction SilentlyContinue -CommandType Application -TotalCount 1
             if ($HugoCommand) {
                 $HVMBin = $HugoCommand.Definition
             }


### PR DESCRIPTION
Adds `-TotalCount 1` to return first found executable only

Fixes: https://github.com/jmooring/hvm/issues/237
